### PR TITLE
pjmedia: change snd_pcm_drain call to snd_pcm_drop

### DIFF
--- a/deps/pjsip/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/deps/pjsip/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -616,7 +616,7 @@ static int ca_thread_func (void *arg)
 
 	tstamp.u64 += nframes;
     }
-    snd_pcm_drain (pcm);
+    snd_pcm_drop (pcm);
     TRACE_((THIS_FILE, "ca_thread_func: Stopped"));
 
     return PJ_SUCCESS;


### PR DESCRIPTION
Previously Blink would lock up after the first call when using
PulseAudio as the input device. The lock up appears to be in the
call to snd_pcm_drain, switching to snd_pcm_drop instead fixes the
issue