### PR TITLE
Fixed tls->verify_server

### DIFF
--- a/deps/pjsip/pjsip/src/pjsip/sip_transport_tls.c
+++ b/deps/pjsip/pjsip/src/pjsip/sip_transport_tls.c
@@ -1629,10 +1629,13 @@ static pj_bool_t on_connect_complete(pj_ssl_sock_t *ssock,
 	unsigned i;
 
 	/* Remote name may be hostname or IP address */
-	if (tls->remote_name.slen)
+	if (tls->remote_name.slen) {
 	    remote_name = &tls->remote_name;
-	else
+	    if (tls->verify_server) PJ_LOG(4,(tls->base.obj_name, "TLS verify: %.*s", remote_name->slen, remote_name->ptr));
+	}
+	else {
 	    remote_name = &tls->base.remote_name.host;
+	}
 
 	/* Start matching remote name with SubjectAltName fields of 
 	 * server certificate.

--- a/sipsimple/core/_helpers.py
+++ b/sipsimple/core/_helpers.py
@@ -4,6 +4,7 @@
 import random
 import socket
 import string
+import re
 
 from application.python.types import MarkerType
 from application.system import host
@@ -17,6 +18,7 @@ __all__ = ['Route', 'ContactURIFactory', 'NoGRUU', 'PublicGRUU', 'TemporaryGRUU'
 
 class Route(object):
     _default_ports = dict(udp=5060, tcp=5060, tls=5061)
+    _allowed_name = re.compile('^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$', re.IGNORECASE)
 
     def __init__(self, address, port=None, transport='udp'):
         self.address = address
@@ -29,10 +31,11 @@ class Route(object):
 
     @address.setter
     def address(self, address):
-        try:
-            socket.inet_aton(address)
-        except:
-            raise ValueError('illegal address: %s' % address)
+        if not (len(address) <= 253 and len(address) >= 1 and all(self._allowed_name.match(x) for x in address.split('.'))):
+            try:
+                socket.inet_aton(address)
+            except:
+               raise ValueError('illegal address: %s' % address)
         self._address = address
 
     @property


### PR DESCRIPTION
Created this patch, after installing blink on Arch Linux from AUR.

Couldn't get my-sip-account->advanced->TLS-Verify-Server working.
Without the TLS Server Verification the communication is vulnerable to MITM attack vectors.

My SIP server for testing was Asterisk 16.5.0 w/ chan_pjsip + TLSv1.2 and the certificate from letsencrypt. For letsencrypt I enabled CA: `/etc/ssl/certs/DST_Root_CA_X3.pem`

I've tested two use cases:
1) NAPTR + SRV records, take a look at `$ dig bogar.io NAPTR` - SSL CERT CN: `bogar.io`
2) NO NAPTR, NO SRV record, just defining outbound proxy w/ TLS - SSL CERT CN: `vox.bogar.io`

Reference:
* [RFC5922](https://tools.ietf.org/html/rfc5922#section-7.3)
* My [python2-simplesip](https://github.com/attilabogar/avb-aur/tree/master/python2-sipsimple) AUR